### PR TITLE
Type resolution improvements & fixes

### DIFF
--- a/src/emit_types_resolve.ts
+++ b/src/emit_types_resolve.ts
@@ -236,8 +236,8 @@ export const resolveEnumMemberValue = (
 
 export const resolveEnumAsUnion = (e: Enum): string => {
   return Array.from(e.members.values())
-    .map((member) => {
-      const value = resolveEnumMemberValue(e, member.name) ?? member.name;
+    .map((member, index) => {
+      const value = resolveEnumMemberValue(e, member.name) ?? index;
       return typeof value === "string" ? `'${value}'` : value.toString();
     })
     .join(" | ");


### PR DESCRIPTION
This PR fixes type resolution issues I've encountered:

### Type Reference Resolution for Unions, Enums, and Arrays

The emitter was incorrectly inlining type definitions instead of referencing already-emitted types:

**Unions**: Named union variants were expanded as anonymous object types instead of referencing existing interfaces
```tsp
union WidgetDetails {
  small: SmallWidget,
  large: LargeWidget,
}
```

```typescript
// Before
export type WidgetDetails = {
  type: unknown,
  weight: number,
  color: 'red' | 'blue'
} | {
  type: unknown,
  size: string,
  capacity: number
};

// After
export type WidgetDetails = SmallWidget | LargeWidget;
```
**Fix**: Check if union variant is a named model in the namespace and reference it by name

**Enums**: Enum types were expanded with their full definition body instead of using the enum name

```tsp
model Widget {
  status: WidgetStatus;
}
```

```typescript
// Before
export interface Widget {
  id: string,
  status: {
    ACTIVE = 'active',
    INACTIVE = 'inactive'
  },
  // ...
}

// After
export interface Widget {
  id: string,
  status: WidgetStatus,
  // ...
}
```
**Fix**: Use `currentNamespace.enums.has()` for consistent namespace checking

**Arrays**: Array element types were inlined instead of referencing existing types

```tsp
model Widget {
  tags?: Tag[];
}
```

```typescript
// Before
export interface Widget {
  // ...
  tags?: ({
    name: string,
    value: string
  })[]
}

// After
export interface Widget {
  // ...
  tags?: (Tag)[]
}
```
**Fix**:  Pass `isNamespaceRoot: false` when resolving array element types to trigger name-based resolution

### Enum Member Type Resolution

Enum member were not implemented, resulting in `unknown` instead of enum references:

```tsp
model SmallWidget {
  type: WidgetSize.SMALL;
}
```

```typescript
// Before
export interface SmallWidget {
  type: unknown,
}

// After
export interface SmallWidget {
  type: WidgetSize.SMALL,
}
```
**Fix**: Add `EnumMember` case handler that emits qualified references as `${t.enum.name}.${t.name}`

### Config

```yaml
emit:
  - "typespec-typescript-emitter"
options:
  "typespec-typescript-emitter":
    root-namespace: "DemoService"
    out-dir: "{project-root}/example/ts"
    enable-types: true
    enable-typeguards: false
    enable-routes: false
    enable-routed-typemap: false
```

### TypeSpec

```typespec
import "@typespec/http";

using Http;

@service({ title: "Widget Service" })
namespace DemoService;

enum WidgetSize {
  SMALL: "small",
  LARGE: "large",
}

enum WidgetStatus {
  ACTIVE: "active",
  INACTIVE: "inactive",
}

model Tag {
  name: string;
  value: string;
}

model SmallWidget {
  type: WidgetSize.SMALL;
  weight: int32;
  color: "red" | "blue";
}

model LargeWidget {
  type: WidgetSize.LARGE;
  size: string;
  capacity: int32;
}

union WidgetDetails {
  small: SmallWidget,
  large: LargeWidget,
}

model Widget {
  @visibility(Lifecycle.Read)
  id: string;
  
  status: WidgetStatus;
  
  details: WidgetDetails;
  
  tags?: Tag[];
}

@error
model Error {
  code: int32;
  message: string;
}

@route("/widgets")
@tag("Widgets")
interface Widgets {
  @get list(): Widget[] | Error;
  @get read(@path id: string): Widget | Error;
  @post create(@body widget: Widget): Widget | Error;
}
```